### PR TITLE
allow server name expansions in config (e.g. server-{01,02}.com)

### DIFF
--- a/cluster_connect/cluster_connect.py
+++ b/cluster_connect/cluster_connect.py
@@ -23,6 +23,8 @@ import terminatorlib.plugin as plugin
 import getpass
 import json
 import os
+import re
+import itertools
 
 pluginpath = os.path.dirname(os.path.realpath(__file__))
 configpath = (pluginpath + "/cluster_connect_config")
@@ -79,6 +81,7 @@ class ClusterConnect(plugin.Plugin):
             sudousers.sort()
             # Get servers and insert cluster for cluster connect
         servers = self.get_property(cluster, 'server')
+        servers = self.expand_servers(servers)
         servers.sort()
         if len(servers) > 1:
             if 'cluster' not in servers:
@@ -176,6 +179,7 @@ class ClusterConnect(plugin.Plugin):
 
                     # Create a group, if the terminals should be grouped
             servers = self.get_property(cluster, 'server')
+            servers = self.expand_servers(servers)
             servers.sort()
 
             # Remove cluster from server, there shouldn't be a server named cluster
@@ -308,3 +312,12 @@ class ClusterConnect(plugin.Plugin):
             if command[len(command) - 1] != '\n':
                 command += '\n'
                 terminal.vte.feed_child(command,-1)
+
+    def expand_servers(self, servers):
+        expanded_servers = list()
+        for server in servers:
+            for x in itertools.product(*[ part.split(',') if i%2 else [part]  for i,part in
+                                          enumerate(re.split(r'\{(.*?)\}',server)) ]):
+                one_server = ''.join(x)
+                expanded_servers.append(one_server)
+        return expanded_servers


### PR DESCRIPTION
Hi, I made this small change for my personal use and thought I'd see if you're interested in merging it.

It's a simple change to allow expansion of server names in the config.

So a config item like this:
`"server": ["test1", "test2", "test3", "test4", "test5", "test6"],`

can become this:
`"server": ["test{1,2,3,4,5,6}"],`