### PR TITLE
Fix - Verbose does not work

### DIFF
--- a/cluster_connect/cluster_connect.py
+++ b/cluster_connect/cluster_connect.py
@@ -311,7 +311,7 @@ class ClusterConnect(plugin.Plugin):
             verbose = self.get_property(cluster, 'verbose')
             if verbose:
                 count = 0
-                command = "-"
+                command += " -"
                 while count < verbose < 3:
                     command += "v"
                     count += 1


### PR DESCRIPTION
Hello,
verbose does not work, if it's activated, the command is reset to blank with a "v"

Thank you