### PR TITLE
Use sudo -iu instead of sudo -su

### DIFF
--- a/cluster_connect/cluster_connect.py
+++ b/cluster_connect/cluster_connect.py
@@ -319,7 +319,7 @@ class ClusterConnect(plugin.Plugin):
             command = command + " " + hostname
 
             if sudo:
-                command = command + " -t sudo -su " + user
+                command = command + " -t sudo -iu " + user
 
                 # Check if a command was generated an pass it to the terminal
             if command[len(command) - 1] != '\n':


### PR DESCRIPTION
This change will more consistently load environment variables associated with the target user.
As a specific example (which brought up this issue for me), trying to execute commands such as "systemctl --user restart example.service" will fail because a required environment variable will not be inherited.